### PR TITLE
Fix error when installing tuistenv from homebrew

### DIFF
--- a/Formula/tuistenv@3.28.0.rb
+++ b/Formula/tuistenv@3.28.0.rb
@@ -1,4 +1,4 @@
-class TuistenvAT3260 < Formula
+class TuistenvAT3280 < Formula
     desc "Managing Tuist versions"
     homepage "https://tuist.io"
     url "https://github.com/tuist/tuist/archive/refs/tags/3.28.0.tar.gz"


### PR DESCRIPTION
```
brew install tuistenv
Error: No available formula with the name "tuistenv@3.28.0". Did you mean tuistenv@3.24.0, tuistenv@3.25.0, tuistenv@3.26.0, tuist@3.24.0, tuist@3.23.0, tuist@3.22.0, tuist@3.18.0, tuist@3.21.0, tuist@3.26.0, tuist@3.25.0 or tuist@3.20.0?
In formula file: /opt/homebrew/Library/Taps/tuist/homebrew-tuist/Formula/tuistenv@3.28.0.rb
Expected to find class TuistenvAT3280, but only found: TuistenvAT3260.
```

The formula class name was wrong