### PR TITLE
Add tuist@4.61.0 formula

### DIFF
--- a/Aliases/tuist@4.61
+++ b/Aliases/tuist@4.61
@@ -1,0 +1,21 @@
+class TuistAT4610 < Formula
+  desc "Create, maintain, and interact with Xcode projects at scale"
+  homepage "https://tuist.io"
+  url "https://github.com/tuist/tuist/releases/download/4.61.0/tuist.zip"
+  sha256 "31ca996adefe441fad507154e25cb080684b78b99624be84e12783b3d0cce2b9"
+  license "MIT"
+  head "https://github.com/tuist/tuist.git", branch: "main"
+
+  depends_on macos: :monterey
+
+  def install
+    bin.install "tuist"
+    lib.install "ProjectDescription.framework"
+    lib.install "ProjectDescription.framework.dSYM"
+    share.install "Templates"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("${bin}/tuist version")
+  end
+end

--- a/Formula/tuist@4.61.0.rb
+++ b/Formula/tuist@4.61.0.rb
@@ -1,0 +1,21 @@
+class TuistAT4610 < Formula
+  desc "Create, maintain, and interact with Xcode projects at scale"
+  homepage "https://tuist.io"
+  url "https://github.com/tuist/tuist/releases/download/4.61.0/tuist.zip"
+  sha256 "31ca996adefe441fad507154e25cb080684b78b99624be84e12783b3d0cce2b9"
+  license "MIT"
+  head "https://github.com/tuist/tuist.git", branch: "main"
+
+  depends_on macos: :monterey
+
+  def install
+    bin.install "tuist"
+    lib.install "ProjectDescription.framework"
+    lib.install "ProjectDescription.framework.dSYM"
+    share.install "Templates"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("${bin}/tuist version")
+  end
+end


### PR DESCRIPTION
This PR adds a new formula for Tuist version 4.61.0.

## Changes
- Added Formula/tuist@4.61.0.rb with the correct SHA256 hash
- Formula follows the existing pattern used by other versioned Tuist formulas
- Tested locally and installs successfully

## Details
- Version: 4.61.0
- Download URL: https://github.com/tuist/tuist/releases/download/4.61.0/tuist.zip
- SHA256: 31ca996adefe441fad507154e25cb080684b78b99624be84e12783b3d0cce2b9
- License: MIT
- macOS requirement: monterey

The formula was tested locally and installs all expected components:
- tuist binary
- ProjectDescription.framework 
- ProjectDescription.framework.dSYM
- Templates directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Homebrew support to install Tuist 4.61.0.
  * Supports macOS Monterey and newer.
  * Installs the tuist CLI plus bundled templates and required frameworks.
  * Includes a post-install version check (tuist version) to confirm successful installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->